### PR TITLE
Update publish script to be more generic

### DIFF
--- a/.github/workflows/push-publish-local.yml
+++ b/.github/workflows/push-publish-local.yml
@@ -9,6 +9,9 @@ name: push-build&deploy-localRepo
 permissions:
   contents: write
 
+env:
+  PREFIX: ${{ github.event.repository.name }}
+
 jobs:
   build-and-push:
     name: Push to local - Build and deploy site to Github Pages on local repo

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,7 @@
+const prefixEnvVar = process.env.NODE_ENV === 'production' && process.env.PREFIX? `/${process.env.PREFIX}`: null;
+
 const repoNameURIPrefix = 
-  process.env.NODE_ENV === 'production' ? '/site-zot' : '';
+  process.env.NODE_ENV === 'production' ? prefixEnvVar??'/site-zot' : '';
 
 module.exports = {
     basePath: repoNameURIPrefix,
@@ -16,6 +18,6 @@ module.exports = {
     },
     env: {
         storePicturesInWEBP: true,
-        generateAndUseBlurImages: true,
+        generateAndUseBlurImages: false,
     },
 };


### PR DESCRIPTION
Because the hosting url of the github pages deployment is not done on the root path of the domain ` / ` but instead done on the `/[repository-name]` path, next js was previously configured to change it's basePath based on if the environment was `production` or `development`, if the environment was `production` it would use a static string with the repository name `site-zot` which made it so the website could not be deployed on a repo with a different name.

This isn't an issue for the `site-zot` repository or it's forks
but this has caused issues in the past before the repository was centralized.

In order to avoid possible future issues like the one mentioned, I've added parametrization on the next js configuration and the local-publish github action to provide the current repository name as an environment variable.

Signed-off-by: Raul Kele <raulkeleblk@gmail.com>